### PR TITLE
Fix for component level relations not being purged

### DIFF
--- a/packages/strapi-plugin-rest-cache/server/utils/config/getRelatedModelsUid.js
+++ b/packages/strapi-plugin-rest-cache/server/utils/config/getRelatedModelsUid.js
@@ -112,7 +112,7 @@ function getRelatedModelsUid(strapi, uid) {
 
       if (attr.type !== 'component') continue;
       if (!attr.component) continue;
-      if (!relatedComponents.includes(attr.component)) continue;
+      if (relatedComponents.includes(attr.component)) continue;
       if (relatedModels[modelKey]) continue;
 
       relatedModels[modelKey] = models[modelKey];


### PR DESCRIPTION
As noted in another PR (https://github.com/strapi-community/plugin-rest-cache/pull/86) and bug https://github.com/strapi-community/plugin-rest-cache/issues/66
 we were having issues with components that contain relations not getting their cache invalidated/purged.

We've done a lot of testing on this (just finalising front end QA), and it appears to now be working as it should (Strapi v4.24.4)

The issue stems from actually extracting the models correctly, but not in the end adding them to the relatedModels array.

A very, very simple change in the end, but like I say, we have tested this and it appears to be working.

Hope this is enough info and you find it useful, and I'm not barking up the wrong tree.

TVM for the plugin, using it very heavily now!

