### PR TITLE
Improvement: Add support for an async custom hitpass function for custom async logic

### DIFF
--- a/packages/strapi-plugin-rest-cache/server/middlewares/recv.js
+++ b/packages/strapi-plugin-rest-cache/server/middlewares/recv.js
@@ -34,7 +34,7 @@ function createRecv(options, { strapi }) {
     const cacheKey = generateCacheKey(ctx, keys);
 
     // hitpass check
-    const lookup = shouldLookup(ctx, hitpass);
+    const lookup = await shouldLookup(ctx, hitpass);
 
     // keep track of the etag
     let etagCached = null;

--- a/packages/strapi-plugin-rest-cache/server/utils/middlewares/shouldLookup.js
+++ b/packages/strapi-plugin-rest-cache/server/utils/middlewares/shouldLookup.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function shouldLookup(
+async function shouldLookup(
   ctx,
   hitpass // @todo: function or boolean => can be optimized
 ) {
@@ -11,7 +11,7 @@ function shouldLookup(
   }
 
   if (type === 'function') {
-    return !hitpass(ctx);
+    return !(await hitpass(ctx));
   }
 
   return false;


### PR DESCRIPTION
# Description
This PR is a suggested change to allow for a custom async hitpass function to be used. 

## Why
We have authorized all our content to avoid people from polling our CMS and also avoid potential exploits being executed. This limited us from using the plugin, as we rely on the authorization step to be executed for every request, even if it adds more latency to our API. After digging through the source code, I noticed that you already allow custom hitpass functions so I decided to raise this PR as it can allow everyone else to do custom async logic before the cache step is executed. (or at least that's how I understand it).

Any feedback is very welcomed!